### PR TITLE
Adapt form to post raw JSON to discourse

### DIFF
--- a/src/components/Account.vue
+++ b/src/components/Account.vue
@@ -428,6 +428,7 @@ import Multiselect from "vue-multiselect";
 import VueTagsInput from '@johmun/vue-tags-input';
 import ajaxFindCountry from "../helpers/cities_api";
 import ajaxFindLanguage from "../helpers/languages_api";
+import submitForm from "../helpers/discourse";
 import CryptoJS from "crypto-js";
 
 export default {
@@ -618,7 +619,17 @@ export default {
       }
     },
     submitForm(){
-      this.next('four');
+      submitForm({
+        account: this.transformForSubmit(this.form.account),
+        profile: this.transformForSubmit(this.form.profile)
+      }).then(() => this.next('four'))
+    },
+    transformForSubmit(obj) {
+      return Object.entries(JSON.parse(JSON.stringify(obj)))
+        .reduce((result, [key, value]) => {
+          result[key] = { value: (value && value.text) || value };
+          return result;
+        }, {});
     },
     addTag(newTag) {
       const tag = {

--- a/src/helpers/discourse.js
+++ b/src/helpers/discourse.js
@@ -62,25 +62,7 @@ const generateUsername = form =>
   )}`;
 
 const generateResponse = form =>
-  Object.values(form)
-    .map(({ body, settings: { omitBody, omitFields }, ...fields }) => [
-      omitBody ? "" : `**${body}**`,
-      Object.entries(fields)
-        .filter(
-          ([
-            ,
-            {
-              settings: { omit }
-            }
-          ]) => !omit
-        )
-        .map(([field, { value }]) =>
-          [omitFields ? "" : `**${field}:** `, value].join("")
-        )
-        .join("\n")
-    ])
-    .flat()
-    .join("\n\n");
+  `<pre>${JSON.stringify(form)}</pre>`
 
 export default (form, errorMessages) =>
   createUser(


### PR DESCRIPTION
This PR is a stab at the functionality outlined here:
https://edgeryders.eu/t/code-review-and-recommendations/12405/100?u=gdpelican

I wasn't able to stand up my discourse instance locally to test, but can confirm that the `createUser` and `createTopic` requests go off with values that look as intended.

It currently wraps the raw JSON form values in a `<pre>` tag to post to a Discourse topic.

Let me know if this works as intended, and if not I can carve out some time this weekend to push it forward more.